### PR TITLE
Only add keyboards and display elements in the UI if the build enables them

### DIFF
--- a/Platformio/src/guis/gui_irReceiver.cpp
+++ b/Platformio/src/guis/gui_irReceiver.cpp
@@ -17,6 +17,8 @@ int messagePos = 0;
 int messageCount = 0;
 bool tabIsInMemory = false;
 
+#if (ENABLE_WIFI_AND_MQTT == 1)
+
 lv_obj_t* objMQTTmessageReceivedTopic;
 lv_obj_t* objMQTTmessageReceivedPayload;
 std::string lastTopic, lastPayload;
@@ -37,6 +39,8 @@ void showMQTTmessage(std::string topic, std::string payload) {
   lastPayload = payload;
   printMQTTmessage();
 }
+
+#endif // ENABLE_WIFI_AND_MQTT
 
 void printIRMessages(bool clearMessages = false) {
   if (!tabIsInMemory) {return;}
@@ -152,6 +156,8 @@ void create_tab_content_irReceiver(lv_obj_t* tab) {
     printIRMessages(true);
   }
 
+  #if (ENABLE_WIFI_AND_MQTT == 1)
+
   // Show MQTT messages we subscribed to ------------------------------------------------------
   menuLabel = lv_label_create(tab);
   lv_label_set_text(menuLabel, "MQTT messages arrived");
@@ -170,6 +176,8 @@ void create_tab_content_irReceiver(lv_obj_t* tab) {
   lv_obj_align(objMQTTmessageReceivedPayload, LV_ALIGN_TOP_LEFT, 0, 8);
 
   printMQTTmessage();
+
+  #endif // ENABLE_WIFI_AND_MQTT
 }
 
 void notify_tab_before_delete_irReceiver(void) {

--- a/Platformio/src/guis/gui_irReceiver.h
+++ b/Platformio/src/guis/gui_irReceiver.h
@@ -8,4 +8,8 @@ void register_gui_irReceiver(void);
 
 // used by commandHandler to show WiFi status
 void showNewIRmessage(std::string);
+
+#if (ENABLE_WIFI_AND_MQTT == 1)
+// used by commandHandler to show WiFi status
 void showMQTTmessage(std::string topic, std::string payload);
+#endif // ENABLE_WIFI_AND_MQTT

--- a/Platformio/src/main.cpp
+++ b/Platformio/src/main.cpp
@@ -8,9 +8,13 @@
 //   special
 #include "devices/misc/device_specialCommands.h"
 #include "applicationInternal/commandHandler.h"
-//   keyboards
+// start:keyboards
+#if (ENABLE_KEYBOARD_MQTT == 1)
 #include "devices/keyboard/device_keyboard_mqtt/device_keyboard_mqtt.h"
+#endif // ENABLE_KEYBOARD_MQTT
+#if (ENABLE_KEYBOARD_BLE == 1)
 #include "devices/keyboard/device_keyboard_ble/device_keyboard_ble.h"
+#endif // ENABLE_KEYBOARD_BLE
 //   TV
 #include "devices/TV/device_samsungTV/device_samsungTV.h"
 //#include "devices/TV/device_lgTV/device_lgTV.h"


### PR DESCRIPTION
In gui_irReceiver.h and `gui_irReceiver.cpp` there is an MQTT display element. that is built/included regardless of if `ENABLE_WIFI_AND_MQTT` is set to 1 or not. Changed this so it's only built/included based on the state of `ENABLE_WIFI_AND_MQTT.`

